### PR TITLE
Add modulefile support

### DIFF
--- a/v0.20/ci/modules.yaml
+++ b/v0.20/ci/modules.yaml
@@ -1,0 +1,1 @@
+../common/modules.yaml

--- a/v0.20/common/modules.yaml
+++ b/v0.20/common/modules.yaml
@@ -1,0 +1,26 @@
+# Refer to https://spack.readthedocs.io/en/latest/module_file_support.html
+modules:
+  default:
+    enable:
+    - tcl
+    roots:
+      tcl: $spack/../release/modules
+      lmod: $spack/../release/lmod
+    tcl:
+      hash_length: 0
+      exclude_implicits: true
+      include:
+      - access-om2
+      - mom5
+      - cice5
+      - libaccessom2
+      - oasis3-mct
+      all:
+        autoload: direct
+        conflict:
+        - '{name}'
+        environment:
+          set:
+            'SPACK_{name}_ROOT': '{prefix}'
+      projections:
+        all: '{name}/{version}'

--- a/v0.20/gadi/modules.yaml
+++ b/v0.20/gadi/modules.yaml
@@ -1,0 +1,1 @@
+../common/modules.yaml


### PR DESCRIPTION
### Verify that Spack recognises the modules.yaml:

```
$ spack config get modules
modules:
  default:
    # Where to install modules
    enable:
    - tcl
    roots:
      tcl: $spack/../release/modules
      lmod: $spack/../release/lmod
    # What type of modules to use ("tcl" and/or "lmod")

    tcl:
      hash_length: 0
      exclude_implicits: true
      include:
      - access-om2
      - mom5
      - cice5
      - libaccessom2
      - oasis3-mct
      all:
        autoload: direct

    # Default configurations if lmod is enabled
        conflict:
        - '{name}'
        environment:
          set:
            SPACK_{name}_ROOT: '{prefix}'
      projections:
        all: '{name}/{version}'
    lmod:
      all:
        autoload: direct
      hierarchy:
      - mpi
  prefix_inspections:
    ./bin:
    - PATH
    ./man:
    - MANPATH
    ./share/man:
    - MANPATH
    ./share/aclocal:
    - ACLOCAL_PATH
    ./lib/pkgconfig:
    - PKG_CONFIG_PATH
    ./lib64/pkgconfig:
    - PKG_CONFIG_PATH
    ./share/pkgconfig:
    - PKG_CONFIG_PATH
    ./:
    - CMAKE_PREFIX_PATH

  # These are configurations for the module set named "default"
```

### Verify that Gadi's module system recognises the modulefiles:
```
$ spack install access-om2 ^netcdf-c@4.7.4 ^netcdf-fortran@4.5.2 ^nci-openmpi@4.0.2 %intel@19.0.5.281
$ module avail

--------- /g/data/[...]/test/release/modules/linux-rocky8-x86_64 ---------
access-om2/latest  libaccessom2/master  oasis3-mct/master  
cice5/master       mom5/master  
```