### PR TITLE
update-deployment-repos: Now uses a deployment environment

### DIFF
--- a/.github/workflows/update-deployment-repos.yml
+++ b/.github/workflows/update-deployment-repos.yml
@@ -7,6 +7,7 @@ jobs:
   update:
     name: Update
     runs-on: ubuntu-latest
+    environment: "Gadi"
     steps:
       - name: Setup SSH
         id: ssh


### PR DESCRIPTION
This enforces sign off before modifying the deployment target. 