### PR TITLE
Pin cmake to 3.24.2 for CI

### DIFF
--- a/v0.20/ci/packages.yaml
+++ b/v0.20/ci/packages.yaml
@@ -1,0 +1,6 @@
+packages:
+  cmake:
+    # Syntax for requirement:
+    require: "@3.24.2"
+    # Syntax for preference:
+    #version: [3.24.2]


### PR DESCRIPTION
The Spack config for gadi already pins CMake to version 3.24.2. See `v0.20/gadi/packages.yaml`:
```
packages:
...
  cmake:
    externals:
    - spec: cmake@3.24.2
      prefix: /apps/cmake/3.24.2
    buildable: false
```
We should do the same in the Spack config for CI.