### PR TITLE
v0.20/ci/packages.yaml: use system perl

### DIFF
--- a/v0.20/ci/packages.yaml
+++ b/v0.20/ci/packages.yaml
@@ -1,4 +1,9 @@
 packages:
+  perl:
+    externals:
+    - spec: perl@5.26.3~cpanm+shared+threads
+      prefix: /usr
+    buildable: false
   cmake:
     # Syntax for requirement:
     require: "@3.24.2"


### PR DESCRIPTION
The Spack config for gadi already uses system perl. See v0.20/gadi/packages.yaml. We should do the same in the Spack config for CI.