### PR TITLE
common/ci/packages.yaml: pin libtool to version 2.4.6 or less

### DIFF
--- a/common/ci/packages.yaml
+++ b/common/ci/packages.yaml
@@ -9,3 +9,5 @@ packages:
     require: "@3.24.2"
     # Syntax for preference:
     #version: [3.24.2]
+  libtool:
+    version: [:2.4.6]


### PR DESCRIPTION
* In Spack v0.21, libevent-2.1.12 complains:
    libtool: Version mismatch error.  This is libtool 2.4.7, but the
    libtool: definition of this LT_INIT comes from libtool 2.4.6.42-b88ce-dirty.
    libtool: You should recreate aclocal.m4 with macros from libtool 2.4.7