### PR TITLE
common/gadi/linux/compilers.yaml: add all the intel-compilers on Gadi

### DIFF
--- a/common/gadi/linux/compilers.yaml
+++ b/common/gadi/linux/compilers.yaml
@@ -1,7 +1,7 @@
 # Completely ignoring higher-level configuration options is supported with the :: notation for keys ...
 compilers::
 - compiler:
-    spec: clang@=15.0.7
+    spec: clang@=16.0.6
     paths:
       cc: /bin/clang
       cxx: /bin/clang++
@@ -27,6 +27,32 @@ compilers::
     environment: {}
     extra_rpaths: []
 - compiler:
+    spec: intel@=19.0.3.199
+    paths:
+      cc: /apps/intel-ct/wrapper/icc
+      cxx: /apps/intel-ct/wrapper/icpc
+      f77: /apps/intel-ct/wrapper/ifort
+      fc: /apps/intel-ct/wrapper/ifort
+    flags: {}
+    operating_system: rocky8
+    target: x86_64
+    modules: [intel-compiler/2019.3.199]
+    environment: {}
+    extra_rpaths: []
+- compiler:
+    spec: intel@=19.0.4.243
+    paths:
+      cc: /apps/intel-ct/wrapper/icc
+      cxx: /apps/intel-ct/wrapper/icpc
+      f77: /apps/intel-ct/wrapper/ifort
+      fc: /apps/intel-ct/wrapper/ifort
+    flags: {}
+    operating_system: rocky8
+    target: x86_64
+    modules: [intel-compiler/2019.4.243]
+    environment: {}
+    extra_rpaths: []
+- compiler:
     spec: intel@=19.0.5.281
     paths:
       cc: /apps/intel-ct/wrapper/icc
@@ -37,5 +63,447 @@ compilers::
     operating_system: rocky8
     target: x86_64
     modules: [intel-compiler/2019.5.281]
+    environment: {}
+    extra_rpaths: []
+- compiler:
+    spec: intel@=19.1.0.166
+    paths:
+      cc: /apps/intel-ct/wrapper/icc
+      cxx: /apps/intel-ct/wrapper/icpc
+      f77: /apps/intel-ct/wrapper/ifort
+      fc: /apps/intel-ct/wrapper/ifort
+    flags: {}
+    operating_system: rocky8
+    target: x86_64
+    modules: [intel-compiler/2020.0.166]
+    environment: {}
+    extra_rpaths: []
+- compiler:
+    spec: intel@=19.1.1.217
+    paths:
+      cc: /apps/intel-ct/wrapper/icc
+      cxx: /apps/intel-ct/wrapper/icpc
+      f77: /apps/intel-ct/wrapper/ifort
+      fc: /apps/intel-ct/wrapper/ifort
+    flags: {}
+    operating_system: rocky8
+    target: x86_64
+    modules: [intel-compiler/2020.1.217]
+    environment: {}
+    extra_rpaths: []
+- compiler:
+    spec: intel@=19.1.2.254
+    paths:
+      cc: /apps/intel-ct/wrapper/icc
+      cxx: /apps/intel-ct/wrapper/icpc
+      f77: /apps/intel-ct/wrapper/ifort
+      fc: /apps/intel-ct/wrapper/ifort
+    flags: {}
+    operating_system: rocky8
+    target: x86_64
+    modules: [intel-compiler/2020.2.254]
+    environment: {}
+    extra_rpaths: []
+- compiler:
+    spec: intel@=19.1.3.304
+    paths:
+      cc: /apps/intel-ct/wrapper/icc
+      cxx: /apps/intel-ct/wrapper/icpc
+      f77: /apps/intel-ct/wrapper/ifort
+      fc: /apps/intel-ct/wrapper/ifort
+    flags: {}
+    operating_system: rocky8
+    target: x86_64
+    modules: [intel-compiler/2020.3.304]
+    environment: {}
+    extra_rpaths: []
+- compiler:
+    spec: dpcpp@=2021.1
+    paths:
+      cc: /apps/intel-ct/wrapper/icx
+      cxx: /apps/intel-ct/wrapper/dpcpp
+      f77: /apps/intel-ct/wrapper/ifx
+      fc: /apps/intel-ct/wrapper/ifx
+    flags: {}
+    operating_system: rocky8
+    target: x86_64
+    modules: [intel-compiler/2021.1.1]
+    environment: {}
+    extra_rpaths: []
+- compiler:
+    spec: intel@=2021.1
+    paths:
+      cc: /apps/intel-ct/wrapper/icc
+      cxx: /apps/intel-ct/wrapper/icpc
+      f77: /apps/intel-ct/wrapper/ifort
+      fc: /apps/intel-ct/wrapper/ifort
+    flags: {}
+    operating_system: rocky8
+    target: x86_64
+    modules: [intel-compiler/2021.1.1]
+    environment: {}
+    extra_rpaths: []
+- compiler:
+    spec: oneapi@=2021.1
+    paths:
+      cc: /apps/intel-ct/wrapper/icx
+      cxx: /apps/intel-ct/wrapper/icpx
+      f77: /apps/intel-ct/wrapper/ifx
+      fc: /apps/intel-ct/wrapper/ifx
+    flags: {}
+    operating_system: rocky8
+    target: x86_64
+    modules: [intel-compiler/2021.1.1]
+    environment: {}
+    extra_rpaths: []
+- compiler:
+    spec: dpcpp@=2021.2.0
+    paths:
+      cc: /apps/intel-ct/wrapper/icx
+      cxx: /apps/intel-ct/wrapper/dpcpp
+      f77: /apps/intel-ct/wrapper/ifx
+      fc: /apps/intel-ct/wrapper/ifx
+    flags: {}
+    operating_system: rocky8
+    target: x86_64
+    modules: [intel-compiler/2021.2.0]
+    environment: {}
+    extra_rpaths: []
+- compiler:
+    spec: intel@=2021.2.0
+    paths:
+      cc: /apps/intel-ct/wrapper/icc
+      cxx: /apps/intel-ct/wrapper/icpc
+      f77: /apps/intel-ct/wrapper/ifort
+      fc: /apps/intel-ct/wrapper/ifort
+    flags: {}
+    operating_system: rocky8
+    target: x86_64
+    modules: [intel-compiler/2021.2.0]
+    environment: {}
+    extra_rpaths: []
+- compiler:
+    spec: oneapi@=2021.2.0
+    paths:
+      cc: /apps/intel-ct/wrapper/icx
+      cxx: /apps/intel-ct/wrapper/icpx
+      f77: /apps/intel-ct/wrapper/ifx
+      fc: /apps/intel-ct/wrapper/ifx
+    flags: {}
+    operating_system: rocky8
+    target: x86_64
+    modules: [intel-compiler/2021.2.0]
+    environment: {}
+    extra_rpaths: []
+- compiler:
+    spec: dpcpp@=2021.3.0
+    paths:
+      cc: /apps/intel-ct/wrapper/icx
+      cxx: /apps/intel-ct/wrapper/dpcpp
+      f77: /apps/intel-ct/wrapper/ifx
+      fc: /apps/intel-ct/wrapper/ifx
+    flags: {}
+    operating_system: rocky8
+    target: x86_64
+    modules: [intel-compiler/2021.3.0]
+    environment: {}
+    extra_rpaths: []
+- compiler:
+    spec: intel@=2021.3.0
+    paths:
+      cc: /apps/intel-ct/wrapper/icc
+      cxx: /apps/intel-ct/wrapper/icpc
+      f77: /apps/intel-ct/wrapper/ifort
+      fc: /apps/intel-ct/wrapper/ifort
+    flags: {}
+    operating_system: rocky8
+    target: x86_64
+    modules: [intel-compiler/2021.3.0]
+    environment: {}
+    extra_rpaths: []
+- compiler:
+    spec: oneapi@=2021.3.0
+    paths:
+      cc: /apps/intel-ct/wrapper/icx
+      cxx: /apps/intel-ct/wrapper/icpx
+      f77: /apps/intel-ct/wrapper/ifx
+      fc: /apps/intel-ct/wrapper/ifx
+    flags: {}
+    operating_system: rocky8
+    target: x86_64
+    modules: [intel-compiler/2021.3.0]
+    environment: {}
+    extra_rpaths: []
+- compiler:
+    spec: dpcpp@=2021.4.0
+    paths:
+      cc: /apps/intel-ct/wrapper/icx
+      cxx: /apps/intel-ct/wrapper/dpcpp
+      f77: /apps/intel-ct/wrapper/ifx
+      fc: /apps/intel-ct/wrapper/ifx
+    flags: {}
+    operating_system: rocky8
+    target: x86_64
+    modules: [intel-compiler/2021.4.0]
+    environment: {}
+    extra_rpaths: []
+- compiler:
+    spec: intel@=2021.4.0
+    paths:
+      cc: /apps/intel-ct/wrapper/icc
+      cxx: /apps/intel-ct/wrapper/icpc
+      f77: /apps/intel-ct/wrapper/ifort
+      fc: /apps/intel-ct/wrapper/ifort
+    flags: {}
+    operating_system: rocky8
+    target: x86_64
+    modules: [intel-compiler/2021.4.0]
+    environment: {}
+    extra_rpaths: []
+- compiler:
+    spec: oneapi@=2021.4.0
+    paths:
+      cc: /apps/intel-ct/wrapper/icx
+      cxx: /apps/intel-ct/wrapper/icpx
+      f77: /apps/intel-ct/wrapper/ifx
+      fc: /apps/intel-ct/wrapper/ifx
+    flags: {}
+    operating_system: rocky8
+    target: x86_64
+    modules: [intel-compiler/2021.4.0]
+    environment: {}
+    extra_rpaths: []
+- compiler:
+    spec: dpcpp@=2022.0.0
+    paths:
+      cc: /apps/intel-ct/wrapper/icx
+      cxx: /apps/intel-ct/wrapper/dpcpp
+      f77: /apps/intel-ct/wrapper/ifx
+      fc: /apps/intel-ct/wrapper/ifx
+    flags: {}
+    operating_system: rocky8
+    target: x86_64
+    modules: [intel-compiler/2021.5.0]
+    environment: {}
+    extra_rpaths: []
+- compiler:
+    spec: intel@=2021.5.0
+    paths:
+      cc: /apps/intel-ct/wrapper/icc
+      cxx: /apps/intel-ct/wrapper/icpc
+      f77: /apps/intel-ct/wrapper/ifort
+      fc: /apps/intel-ct/wrapper/ifort
+    flags: {}
+    operating_system: rocky8
+    target: x86_64
+    modules: [intel-compiler/2021.5.0]
+    environment: {}
+    extra_rpaths: []
+- compiler:
+    spec: oneapi@=2022.0.0
+    paths:
+      cc: /apps/intel-ct/wrapper/icx
+      cxx: /apps/intel-ct/wrapper/icpx
+      f77: /apps/intel-ct/wrapper/ifx
+      fc: /apps/intel-ct/wrapper/ifx
+    flags: {}
+    operating_system: rocky8
+    target: x86_64
+    modules: [intel-compiler/2021.5.0]
+    environment: {}
+    extra_rpaths: []
+- compiler:
+    spec: dpcpp@=2022.1.0
+    paths:
+      cc: /apps/intel-ct/wrapper/icx
+      cxx: /apps/intel-ct/wrapper/dpcpp
+      f77: /apps/intel-ct/wrapper/ifx
+      fc: /apps/intel-ct/wrapper/ifx
+    flags: {}
+    operating_system: rocky8
+    target: x86_64
+    modules: [intel-compiler/2021.6.0]
+    environment: {}
+    extra_rpaths: []
+- compiler:
+    spec: intel@=2021.6.0
+    paths:
+      cc: /apps/intel-ct/wrapper/icc
+      cxx: /apps/intel-ct/wrapper/icpc
+      f77: /apps/intel-ct/wrapper/ifort
+      fc: /apps/intel-ct/wrapper/ifort
+    flags: {}
+    operating_system: rocky8
+    target: x86_64
+    modules: [intel-compiler/2021.6.0]
+    environment: {}
+    extra_rpaths: []
+- compiler:
+    spec: oneapi@=2022.1.0
+    paths:
+      cc: /apps/intel-ct/wrapper/icx
+      cxx: /apps/intel-ct/wrapper/icpx
+      f77: /apps/intel-ct/wrapper/ifx
+      fc: /apps/intel-ct/wrapper/ifx
+    flags: {}
+    operating_system: rocky8
+    target: x86_64
+    modules: [intel-compiler/2021.6.0]
+    environment: {}
+    extra_rpaths: []
+- compiler:
+    spec: dpcpp@=2022.2.0
+    paths:
+      cc: /apps/intel-ct/wrapper/icx
+      cxx: /apps/intel-ct/wrapper/dpcpp
+      f77: /apps/intel-ct/wrapper/ifx
+      fc: /apps/intel-ct/wrapper/ifx
+    flags: {}
+    operating_system: rocky8
+    target: x86_64
+    modules: [intel-compiler/2021.7.0]
+    environment: {}
+    extra_rpaths: []
+- compiler:
+    spec: intel@=2021.7.0
+    paths:
+      cc: /apps/intel-ct/wrapper/icc
+      cxx: /apps/intel-ct/wrapper/icpc
+      f77: /apps/intel-ct/wrapper/ifort
+      fc: /apps/intel-ct/wrapper/ifort
+    flags: {}
+    operating_system: rocky8
+    target: x86_64
+    modules: [intel-compiler/2021.7.0]
+    environment: {}
+    extra_rpaths: []
+- compiler:
+    spec: oneapi@=2022.2.0
+    paths:
+      cc: /apps/intel-ct/wrapper/icx
+      cxx: /apps/intel-ct/wrapper/icpx
+      f77: /apps/intel-ct/wrapper/ifx
+      fc: /apps/intel-ct/wrapper/ifx
+    flags: {}
+    operating_system: rocky8
+    target: x86_64
+    modules: [intel-compiler/2021.7.0]
+    environment: {}
+    extra_rpaths: []
+- compiler:
+    spec: dpcpp@=2023.0.0
+    paths:
+      cc: /apps/intel-ct/wrapper/icx
+      cxx: /apps/intel-ct/wrapper/dpcpp
+      f77: /apps/intel-ct/wrapper/ifx
+      fc: /apps/intel-ct/wrapper/ifx
+    flags: {}
+    operating_system: rocky8
+    target: x86_64
+    modules: [intel-compiler/2021.8.0]
+    environment: {}
+    extra_rpaths: []
+- compiler:
+    spec: intel@=2021.8.0
+    paths:
+      cc: /apps/intel-ct/wrapper/icc
+      cxx: /apps/intel-ct/wrapper/icpc
+      f77: /apps/intel-ct/wrapper/ifort
+      fc: /apps/intel-ct/wrapper/ifort
+    flags: {}
+    operating_system: rocky8
+    target: x86_64
+    modules: [intel-compiler/2021.8.0]
+    environment: {}
+    extra_rpaths: []
+- compiler:
+    spec: oneapi@=2023.0.0
+    paths:
+      cc: /apps/intel-ct/wrapper/icx
+      cxx: /apps/intel-ct/wrapper/icpx
+      f77: /apps/intel-ct/wrapper/ifx
+      fc: /apps/intel-ct/wrapper/ifx
+    flags: {}
+    operating_system: rocky8
+    target: x86_64
+    modules: [intel-compiler/2021.8.0]
+    environment: {}
+    extra_rpaths: []
+- compiler:
+    spec: dpcpp@=2023.2.0
+    paths:
+      cc: /apps/intel-ct/wrapper/icx
+      cxx: /apps/intel-ct/wrapper/dpcpp
+      f77: /apps/intel-ct/wrapper/ifx
+      fc: /apps/intel-ct/wrapper/ifx
+    flags: {}
+    operating_system: rocky8
+    target: x86_64
+    modules: [intel-compiler/2021.10.0]
+    environment: {}
+    extra_rpaths: []
+- compiler:
+    spec: intel@=2021.10.0
+    paths:
+      cc: /apps/intel-ct/wrapper/icc
+      cxx: /apps/intel-ct/wrapper/icpc
+      f77: /apps/intel-ct/wrapper/ifort
+      fc: /apps/intel-ct/wrapper/ifort
+    flags: {}
+    operating_system: rocky8
+    target: x86_64
+    modules: [intel-compiler/2021.10.0]
+    environment: {}
+    extra_rpaths: []
+- compiler:
+    spec: oneapi@=2023.2.0
+    paths:
+      cc: /apps/intel-ct/wrapper/icx
+      cxx: /apps/intel-ct/wrapper/icpx
+      f77: /apps/intel-ct/wrapper/ifx
+      fc: /apps/intel-ct/wrapper/ifx
+    flags: {}
+    operating_system: rocky8
+    target: x86_64
+    modules: [intel-compiler/2021.10.0]
+    environment: {}
+    extra_rpaths: []
+- compiler:
+    spec: dpcpp@=2024.0.2
+    paths:
+      cc: /apps/intel-tools/wrappers/icx
+      cxx: /apps/intel-tools/wrappers/dpcpp
+      f77: /apps/intel-tools/wrappers/ifx
+      fc: /apps/intel-tools/wrappers/ifx
+    flags: {}
+    operating_system: rocky8
+    target: x86_64
+    modules: [intel-compiler-llvm/2024.0.2]
+    environment: {}
+    extra_rpaths: []
+- compiler:
+    spec: intel@=2021.11.1
+    paths:
+      cc: null
+      cxx: null
+      f77: /apps/intel-tools/intel-compiler-llvm/2024.0.2/bin/ifort
+      fc: /apps/intel-tools/intel-compiler-llvm/2024.0.2/bin/ifort
+    flags: {}
+    operating_system: rocky8
+    target: x86_64
+    modules: [intel-compiler-llvm/2024.0.2]
+    environment: {}
+    extra_rpaths: []
+- compiler:
+    spec: oneapi@=2024.0.2
+    paths:
+      cc: /apps/intel-tools/wrappers/icx
+      cxx: /apps/intel-tools/wrappers/icpx
+      f77: /apps/intel-tools/wrappers/ifx
+      fc: /apps/intel-tools/wrappers/ifx
+    flags: {}
+    operating_system: rocky8
+    target: x86_64
+    modules: [intel-compiler-llvm/2024.0.2]
     environment: {}
     extra_rpaths: []


### PR DESCRIPTION
1) for i in $(module avail -t intel-compiler/ intel-compiler-llvm/ | grep ^intel-compiler | tr '\n' ' '); do echo "= $i ="; module load $i; spack compiler find; module unload $i ; done 2>&1 | tee ~/spack.yaml.log

2) Copy the module name into the yaml file's modules list variable.