### PR TITLE
common/ci/packages.yaml: require CMake 3.24.4

### DIFF
--- a/common/ci/packages.yaml
+++ b/common/ci/packages.yaml
@@ -6,8 +6,8 @@ packages:
     buildable: false
   cmake:
     # Syntax for requirement:
-    require: "@3.24.2"
+    require: "@3.24.4"
     # Syntax for preference:
-    #version: [3.24.2]
+    #version: [3.24.4]
   libtool:
     version: [:2.4.6]


### PR DESCRIPTION
* CMake 3.24.2 is deprecated in Spack v0.22.