### PR TITLE
Avoid using HDF5 version 1.14.3

### DIFF
--- a/v0.21/gadi/packages.yaml
+++ b/v0.21/gadi/packages.yaml
@@ -52,3 +52,7 @@ packages:
       prefix: /apps/openmpi/4.1.5
       modules: [openmpi/4.1.5]
     buildable: false
+  hdf5:
+    require:
+    - one_of: ['@1.14.3','@:']
+      message: 'FPE bug in hdf5@1.14.3 is not patched in Spack versions earlier than v0.22'


### PR DESCRIPTION
Closes #33 . Tested by appending
```
        depends_on("hdf5@1.14.3")
```
to
```
     with when("@access-esm1.5"):
         depends_on("oasis3-mct@access-esm1.5")
```
in https://github.com/ACCESS-NRI/spack-packages/blob/main/packages/mom5/package.py . Running
```
$ spack install mom5@access-esm1.5%intel@19.0.5.281 arch=linux-rocky8-x86_64
```
then results in
```
==> Error: concretization failed for the following reasons:

   1. FPE bug in hdf5@1.14.3 is not patched in Spack versions earlier than v0.22
```