### PR TITLE
common/modules.yaml: remove ACCESS-OM2 specific include list

### DIFF
--- a/common/modules.yaml
+++ b/common/modules.yaml
@@ -8,13 +8,16 @@ modules:
       lmod: $spack/../release/lmod
     tcl:
       hash_length: 0
+      # Looks like we need to use exclude_implicits because Gadi has
+      # an old version of modules:
+      # $ module --version
+      # Modules Release 4.3.0 (2019-07-26)
+      # https://github.com/spack/spack/issues/40940
       exclude_implicits: true
-      include:
-      - access-om2
-      - mom5
-      - cice5
-      - libaccessom2
-      - oasis3-mct
+      # Does this PR imply exclude_implicits and hide_implicits can not
+      # be used together?:
+      # https://github.com/spack/spack/pull/40955
+      # hide_implicits: true
       all:
         autoload: direct
         conflict:


### PR DESCRIPTION
* The ACCESS-OM2 environment's spack.yaml will contain the include list.