### PR TITLE
common/config.yaml: override environments_root and source_cache

### DIFF
--- a/common/config.yaml
+++ b/common/config.yaml
@@ -2,3 +2,7 @@ config:
   install_tree:
     # Completely ignoring higher-level configuration options is supported with the :: notation for keys ...
     root:: $spack/../release
+  # Available in v0.20.0
+  source_cache: $spack/../sourcecache
+  # Available in v0.20.0
+  environments_root: $spack/../environments


### PR DESCRIPTION
Overriding `environments_root` and `source_cache` to point outside of the `spack` git repository takes us one step closer to an immutable spack directory. Thanks @atteggiani for prompting me to look at this.