### PR TITLE
common/gadi/packages.yaml: add extra_attributes to openmpi spec

### DIFF
--- a/common/gadi/packages.yaml
+++ b/common/gadi/packages.yaml
@@ -14,41 +14,279 @@ packages:
       prefix: /apps/cmake/3.24.2
     buildable: false
   openmpi:
+    # https://spack.readthedocs.io/en/latest/configuration.html#environment-modifications
     externals:
-    - spec: openmpi@4.0.1
+    - spec: openmpi@4.0.1 %gcc
       prefix: /apps/openmpi/4.0.1
       modules: [openmpi/4.0.1]
-    - spec: openmpi@4.0.2
+      extra_attributes:
+        environment:
+          prepend_path:
+            CMAKE_PREFIX_PATH: /apps/openmpi/4.0.1/include/GNU
+    - spec: openmpi@4.0.2 %gcc
       prefix: /apps/openmpi/4.0.2
       modules: [openmpi/4.0.2]
-    - spec: openmpi@4.0.3
+      extra_attributes:
+        environment:
+          prepend_path:
+            CMAKE_PREFIX_PATH: /apps/openmpi/4.0.2/include/GNU
+    - spec: openmpi@4.0.3 %gcc
       prefix: /apps/openmpi/4.0.3
       modules: [openmpi/4.0.3]
-    - spec: openmpi@4.0.4
+      extra_attributes:
+        environment:
+          prepend_path:
+            CMAKE_PREFIX_PATH: /apps/openmpi/4.0.3/include/GNU
+    - spec: openmpi@4.0.4 %gcc
       prefix: /apps/openmpi/4.0.4
       modules: [openmpi/4.0.4]
-    - spec: openmpi@4.0.5
+      extra_attributes:
+        environment:
+          prepend_path:
+            CMAKE_PREFIX_PATH: /apps/openmpi/4.0.4/include/GNU
+    - spec: openmpi@4.0.5 %gcc
       prefix: /apps/openmpi/4.0.5
       modules: [openmpi/4.0.5]
-    - spec: openmpi@4.0.6
+      extra_attributes:
+        environment:
+          prepend_path:
+            CMAKE_PREFIX_PATH: /apps/openmpi/4.0.5/include/GNU
+    - spec: openmpi@4.0.6 %gcc
       prefix: /apps/openmpi/4.0.6
       modules: [openmpi/4.0.6]
-    - spec: openmpi@4.0.7
+      extra_attributes:
+        environment:
+          prepend_path:
+            CMAKE_PREFIX_PATH: /apps/openmpi/4.0.6/include/GNU
+    - spec: openmpi@4.0.7 %gcc
       prefix: /apps/openmpi/4.0.7
       modules: [openmpi/4.0.7]
-    - spec: openmpi@4.1.0
+      extra_attributes:
+        environment:
+          prepend_path:
+            CMAKE_PREFIX_PATH: /apps/openmpi/4.0.7/include/GNU
+    - spec: openmpi@4.1.0 %gcc
       prefix: /apps/openmpi/4.1.0
       modules: [openmpi/4.1.0]
-    - spec: openmpi@4.1.1
+      extra_attributes:
+        environment:
+          prepend_path:
+            CMAKE_PREFIX_PATH: /apps/openmpi/4.1.0/include/GNU
+    - spec: openmpi@4.1.1 %gcc
       prefix: /apps/openmpi/4.1.1
       modules: [openmpi/4.1.1]
-    - spec: openmpi@4.1.2
+      extra_attributes:
+        environment:
+          prepend_path:
+            CMAKE_PREFIX_PATH: /apps/openmpi/4.1.1/include/GNU
+    - spec: openmpi@4.1.2 %gcc
       prefix: /apps/openmpi/4.1.2
       modules: [openmpi/4.1.2]
-    - spec: openmpi@4.1.3
+      extra_attributes:
+        environment:
+          prepend_path:
+            CMAKE_PREFIX_PATH: /apps/openmpi/4.1.2/include/GNU
+    - spec: openmpi@4.1.3 %gcc
       prefix: /apps/openmpi/4.1.3
       modules: [openmpi/4.1.3]
-    - spec: openmpi@4.1.5
+      extra_attributes:
+        environment:
+          prepend_path:
+            CMAKE_PREFIX_PATH: /apps/openmpi/4.1.3/include/GNU
+    - spec: openmpi@4.1.4 %gcc
+      prefix: /apps/openmpi/4.1.4
+      modules: [openmpi/4.1.4]
+      extra_attributes:
+        environment:
+          prepend_path:
+            CMAKE_PREFIX_PATH: /apps/openmpi/4.1.4/include/GNU
+    - spec: openmpi@4.1.5 %gcc
       prefix: /apps/openmpi/4.1.5
       modules: [openmpi/4.1.5]
+      extra_attributes:
+        environment:
+          prepend_path:
+            CMAKE_PREFIX_PATH: /apps/openmpi/4.1.5/include/GNU
+    - spec: openmpi@4.0.1 %intel
+      prefix: /apps/openmpi/4.0.1
+      modules: [openmpi/4.0.1]
+      extra_attributes:
+        environment:
+          prepend_path:
+            CMAKE_PREFIX_PATH: /apps/openmpi/4.0.1/include/Intel
+    - spec: openmpi@4.0.2 %intel
+      prefix: /apps/openmpi/4.0.2
+      modules: [openmpi/4.0.2]
+      extra_attributes:
+        environment:
+          prepend_path:
+            CMAKE_PREFIX_PATH: /apps/openmpi/4.0.2/include/Intel
+    - spec: openmpi@4.0.3 %intel
+      prefix: /apps/openmpi/4.0.3
+      modules: [openmpi/4.0.3]
+      extra_attributes:
+        environment:
+          prepend_path:
+            CMAKE_PREFIX_PATH: /apps/openmpi/4.0.3/include/Intel
+    - spec: openmpi@4.0.4 %intel
+      prefix: /apps/openmpi/4.0.4
+      modules: [openmpi/4.0.4]
+      extra_attributes:
+        environment:
+          prepend_path:
+            CMAKE_PREFIX_PATH: /apps/openmpi/4.0.4/include/Intel
+    - spec: openmpi@4.0.5 %intel
+      prefix: /apps/openmpi/4.0.5
+      modules: [openmpi/4.0.5]
+      extra_attributes:
+        environment:
+          prepend_path:
+            CMAKE_PREFIX_PATH: /apps/openmpi/4.0.5/include/Intel
+    - spec: openmpi@4.0.6 %intel
+      prefix: /apps/openmpi/4.0.6
+      modules: [openmpi/4.0.6]
+      extra_attributes:
+        environment:
+          prepend_path:
+            CMAKE_PREFIX_PATH: /apps/openmpi/4.0.6/include/Intel
+    - spec: openmpi@4.0.7 %intel
+      prefix: /apps/openmpi/4.0.7
+      modules: [openmpi/4.0.7]
+      extra_attributes:
+        environment:
+          prepend_path:
+            CMAKE_PREFIX_PATH: /apps/openmpi/4.0.7/include/Intel
+    - spec: openmpi@4.1.0 %intel
+      prefix: /apps/openmpi/4.1.0
+      modules: [openmpi/4.1.0]
+      extra_attributes:
+        environment:
+          prepend_path:
+            CMAKE_PREFIX_PATH: /apps/openmpi/4.1.0/include/Intel
+    - spec: openmpi@4.1.1 %intel
+      prefix: /apps/openmpi/4.1.1
+      modules: [openmpi/4.1.1]
+      extra_attributes:
+        environment:
+          prepend_path:
+            CMAKE_PREFIX_PATH: /apps/openmpi/4.1.1/include/Intel
+    - spec: openmpi@4.1.2 %intel
+      prefix: /apps/openmpi/4.1.2
+      modules: [openmpi/4.1.2]
+      extra_attributes:
+        environment:
+          prepend_path:
+            CMAKE_PREFIX_PATH: /apps/openmpi/4.1.2/include/Intel
+    - spec: openmpi@4.1.3 %intel
+      prefix: /apps/openmpi/4.1.3
+      modules: [openmpi/4.1.3]
+      extra_attributes:
+        environment:
+          prepend_path:
+            CMAKE_PREFIX_PATH: /apps/openmpi/4.1.3/include/Intel
+    - spec: openmpi@4.1.4 %intel
+      prefix: /apps/openmpi/4.1.4
+      modules: [openmpi/4.1.4]
+      extra_attributes:
+        environment:
+          prepend_path:
+            CMAKE_PREFIX_PATH: /apps/openmpi/4.1.4/include/Intel
+    - spec: openmpi@4.1.5 %intel
+      prefix: /apps/openmpi/4.1.5
+      modules: [openmpi/4.1.5]
+      extra_attributes:
+        environment:
+          prepend_path:
+            CMAKE_PREFIX_PATH: /apps/openmpi/4.1.5/include/Intel
+    - spec: openmpi@4.0.1 %oneapi
+      prefix: /apps/openmpi/4.0.1
+      modules: [openmpi/4.0.1]
+      extra_attributes:
+        environment:
+          prepend_path:
+            CMAKE_PREFIX_PATH: /apps/openmpi/4.0.1/include/Intel
+    - spec: openmpi@4.0.2 %oneapi
+      prefix: /apps/openmpi/4.0.2
+      modules: [openmpi/4.0.2]
+      extra_attributes:
+        environment:
+          prepend_path:
+            CMAKE_PREFIX_PATH: /apps/openmpi/4.0.2/include/Intel
+    - spec: openmpi@4.0.3 %oneapi
+      prefix: /apps/openmpi/4.0.3
+      modules: [openmpi/4.0.3]
+      extra_attributes:
+        environment:
+          prepend_path:
+            CMAKE_PREFIX_PATH: /apps/openmpi/4.0.3/include/Intel
+    - spec: openmpi@4.0.4 %oneapi
+      prefix: /apps/openmpi/4.0.4
+      modules: [openmpi/4.0.4]
+      extra_attributes:
+        environment:
+          prepend_path:
+            CMAKE_PREFIX_PATH: /apps/openmpi/4.0.4/include/Intel
+    - spec: openmpi@4.0.5 %oneapi
+      prefix: /apps/openmpi/4.0.5
+      modules: [openmpi/4.0.5]
+      extra_attributes:
+        environment:
+          prepend_path:
+            CMAKE_PREFIX_PATH: /apps/openmpi/4.0.5/include/Intel
+    - spec: openmpi@4.0.6 %oneapi
+      prefix: /apps/openmpi/4.0.6
+      modules: [openmpi/4.0.6]
+      extra_attributes:
+        environment:
+          prepend_path:
+            CMAKE_PREFIX_PATH: /apps/openmpi/4.0.6/include/Intel
+    - spec: openmpi@4.0.7 %oneapi
+      prefix: /apps/openmpi/4.0.7
+      modules: [openmpi/4.0.7]
+      extra_attributes:
+        environment:
+          prepend_path:
+            CMAKE_PREFIX_PATH: /apps/openmpi/4.0.7/include/Intel
+    - spec: openmpi@4.1.0 %oneapi
+      prefix: /apps/openmpi/4.1.0
+      modules: [openmpi/4.1.0]
+      extra_attributes:
+        environment:
+          prepend_path:
+            CMAKE_PREFIX_PATH: /apps/openmpi/4.1.0/include/Intel
+    - spec: openmpi@4.1.1 %oneapi
+      prefix: /apps/openmpi/4.1.1
+      modules: [openmpi/4.1.1]
+      extra_attributes:
+        environment:
+          prepend_path:
+            CMAKE_PREFIX_PATH: /apps/openmpi/4.1.1/include/Intel
+    - spec: openmpi@4.1.2 %oneapi
+      prefix: /apps/openmpi/4.1.2
+      modules: [openmpi/4.1.2]
+      extra_attributes:
+        environment:
+          prepend_path:
+            CMAKE_PREFIX_PATH: /apps/openmpi/4.1.2/include/Intel
+    - spec: openmpi@4.1.3 %oneapi
+      prefix: /apps/openmpi/4.1.3
+      modules: [openmpi/4.1.3]
+      extra_attributes:
+        environment:
+          prepend_path:
+            CMAKE_PREFIX_PATH: /apps/openmpi/4.1.3/include/Intel
+    - spec: openmpi@4.1.4 %oneapi
+      prefix: /apps/openmpi/4.1.4
+      modules: [openmpi/4.1.4]
+      extra_attributes:
+        environment:
+          prepend_path:
+            CMAKE_PREFIX_PATH: /apps/openmpi/4.1.4/include/Intel
+    - spec: openmpi@4.1.5 %oneapi
+      prefix: /apps/openmpi/4.1.5
+      modules: [openmpi/4.1.5]
+      extra_attributes:
+        environment:
+          prepend_path:
+            CMAKE_PREFIX_PATH: /apps/openmpi/4.1.5/include/Intel
     buildable: false


### PR DESCRIPTION
Set $CMAKE_PREFIX_PATH to workaround Gadi's openmpi directory layout. This means MPI compiler wrappers being explicitly passed to CMake are not required in SPDs, anymore.

Without this change, the upstream Spack's FMS package will not build: https://github.com/spack/spack/issues/45358