### PR TITLE
Add configuration for setonix

### DIFF
--- a/common/setonix/packages.yaml
+++ b/common/setonix/packages.yaml
@@ -1,0 +1,16 @@
+packages:
+  perl:
+    externals:
+    - spec: perl@5.26.1
+      prefix: /usr
+    buildable: false
+  cmake:
+    externals:
+    - spec: cmake@3.27.7
+      prefix: /software/setonix/2024.05/software/linux-sles15-zen3/gcc-12.2.0/cmake-3.27.7-ylzyjfdeksq6jhz63zyo3qixmhm6t4kx/
+      modules: [cmake/3.27.7]
+    buildable: true
+  libtool:
+    version: [:2.4.6]
+  openmpi:
+    version: [4.1.1:]

--- a/v0.22/setonix/concretizer.yaml
+++ b/v0.22/setonix/concretizer.yaml
@@ -1,0 +1,1 @@
+../../common/concretizer.yaml

--- a/v0.22/setonix/config.yaml
+++ b/v0.22/setonix/config.yaml
@@ -1,0 +1,1 @@
+../../common/config.yaml

--- a/v0.22/setonix/modules.yaml
+++ b/v0.22/setonix/modules.yaml
@@ -1,0 +1,1 @@
+../../common/modules.yaml

--- a/v0.22/setonix/packages.yaml
+++ b/v0.22/setonix/packages.yaml
@@ -1,0 +1,1 @@
+../../common/setonix/packages.yaml

--- a/v0.22/setonix/repos.yaml
+++ b/v0.22/setonix/repos.yaml
@@ -1,0 +1,1 @@
+../../common/repos.yaml


### PR DESCRIPTION
This PR contains the configuration used to successfully build ACCESS-OM2 on Setonix using our own Spack v0.22 instance.

The `spack.yaml` that was used:
```
# This is a Spack Environment file.
#
# It describes a set of packages to be installed, along with
# configuration settings.
spack:
  # add package specs to the `specs` list
  specs:
    - access-om2@git.2024.03.0
  packages:
    cice5:
      require:
        - '@git.2023.10.19'
    mom5:
      require:
        - '@git.2023.11.09'
    libaccessom2:
      require:
        - '@git.2023.10.26'
    oasis3-mct:
      require:
        - '@git.2023.11.09'
    netcdf-c:
      require:
        - '@4.7.4'
    netcdf-fortran:
      require:
        - '@4.5.2'
    parallelio:
      require:
        - '@2.5.2'
    openmpi:
      require:
        - '@4.1.5'
    all:
      require:
        - '%intel@2021.2.0'
        - 'target=x86_64'
  view: true
  concretizer:
    unify: true
  modules:
    default:
      tcl:
        include:
          - access-om2
          - mom5
          - cice5
          - libaccessom2
          - oasis3-mct
        projections:
          access-om2: '{name}/2024.03.0'
          cice5: '{name}/2023.10.19-{hash:7}'
          mom5: '{name}/2023.11.09-{hash:7}'
          libaccessom2: '{name}/2023.10.26-{hash:7}'
          oasis3-mct: '{name}/2023.11.09-{hash:7}'
```