### PR TITLE
Add latest version of the Intel OneAPI compilers on gadi

### DIFF
--- a/common/gadi/linux/compilers.yaml
+++ b/common/gadi/linux/compilers.yaml
@@ -378,6 +378,19 @@ compilers::
     environment: {}
     extra_rpaths: []
 - compiler:
+    spec: oneapi@=2024.2.1
+    paths:
+      cc: /apps/intel-tools/wrappers/icx
+      cxx: /apps/intel-tools/wrappers/icpx
+      f77: /apps/intel-tools/wrappers/ifx
+      fc: /apps/intel-tools/wrappers/ifx
+    flags: {}
+    operating_system: rocky8
+    target: x86_64
+    modules: [intel-compiler-llvm/2024.2.1]
+    environment: {}
+    extra_rpaths: []
+- compiler:
     spec: gcc@=10.3.0
     paths:
       cc: /apps/gcc/10.3.0/wrappers/gcc


### PR DESCRIPTION
FMS only compiles correctly with the latest version of the Intel OneAPI compilers available on gadi.