### PR TITLE
Added oneAPI 2025 compiler

### DIFF
--- a/common/gadi/linux/compilers.yaml
+++ b/common/gadi/linux/compilers.yaml
@@ -391,6 +391,19 @@ compilers::
     environment: {}
     extra_rpaths: []
 - compiler:
+    spec: oneapi@=2025.0.4
+    paths:
+      cc: /apps/intel-tools/wrappers/icx
+      cxx: /apps/intel-tools/wrappers/icpx
+      f77: /apps/intel-tools/wrappers/ifx
+      fc: /apps/intel-tools/wrappers/ifx
+    flags: {}
+    operating_system: rocky8
+    target: x86_64
+    modules: [intel-compiler-llvm/2025.0.4]
+    environment: {}
+    extra_rpaths: []
+- compiler:
     spec: gcc@=10.3.0
     paths:
       cc: /apps/gcc/10.3.0/wrappers/gcc


### PR DESCRIPTION
The 2025 oneAPI is now available on `gadi`