### PR TITLE
Update ci spack-config for multi-container CI builds

### DIFF
--- a/common/ci-runner/upstreams.yaml
+++ b/common/ci-runner/upstreams.yaml
@@ -1,0 +1,5 @@
+upstreams:
+  upstream:
+    # Assumes that from the runners point of view, the volume mount 
+    # point for the containerised upstream install_tree is /opt/upstream
+    install_tree: /opt/upstream

--- a/common/ci-upstream/config.yaml
+++ b/common/ci-upstream/config.yaml
@@ -1,0 +1,8 @@
+config:
+  install_tree:
+    # Completely ignoring higher-level configuration options is supported with the :: notation for keys ...
+    root:: $spack/../upstream
+  # Available in v0.20.0
+  source_cache: $spack/../sourcecache
+  # Available in v0.20.0
+  environments_root: $spack/../environments

--- a/common/ci-upstream/modules.yaml
+++ b/common/ci-upstream/modules.yaml
@@ -1,0 +1,24 @@
+# Refer to https://spack.readthedocs.io/en/latest/module_file_support.html
+modules:
+  default:
+    enable:
+    - tcl
+    roots:
+      tcl: $spack/../upstream/modules
+      lmod: $spack/../upstream/lmod
+    tcl:
+      hash_length: 0
+      # Looks like we need to use exclude_implicits because Gadi has
+      # an old version of modules:
+      # $ module --version
+      # Modules Release 4.3.0 (2019-07-26)
+      # https://github.com/spack/spack/issues/40940
+      exclude_implicits: true
+      # Does this PR imply exclude_implicits and hide_implicits can not
+      # be used together?:
+      # https://github.com/spack/spack/pull/40955
+      # hide_implicits: true
+      all:
+        autoload: direct
+      projections:
+        all: '{name}/{version}-{hash:7}'

--- a/v0.22/ci-runner/concretizer.yaml
+++ b/v0.22/ci-runner/concretizer.yaml
@@ -1,0 +1,1 @@
+../../common/concretizer.yaml

--- a/v0.22/ci-runner/config.yaml
+++ b/v0.22/ci-runner/config.yaml
@@ -1,0 +1,1 @@
+../../common/config.yaml

--- a/v0.22/ci-runner/modules.yaml
+++ b/v0.22/ci-runner/modules.yaml
@@ -1,0 +1,1 @@
+../../common/modules.yaml

--- a/v0.22/ci-runner/packages.yaml
+++ b/v0.22/ci-runner/packages.yaml
@@ -1,0 +1,1 @@
+../../common/ci/packages.yaml

--- a/v0.22/ci-runner/repos.yaml
+++ b/v0.22/ci-runner/repos.yaml
@@ -1,0 +1,1 @@
+../../common/repos.yaml

--- a/v0.22/ci-runner/upstreams.yaml
+++ b/v0.22/ci-runner/upstreams.yaml
@@ -1,0 +1,1 @@
+../../common/ci-runner/upstreams.yaml

--- a/v0.22/ci-upstream/concretizer.yaml
+++ b/v0.22/ci-upstream/concretizer.yaml
@@ -1,0 +1,1 @@
+../../common/concretizer.yaml

--- a/v0.22/ci-upstream/config.yaml
+++ b/v0.22/ci-upstream/config.yaml
@@ -1,0 +1,1 @@
+../../common/ci-upstream/config.yaml

--- a/v0.22/ci-upstream/modules.yaml
+++ b/v0.22/ci-upstream/modules.yaml
@@ -1,0 +1,1 @@
+../../common/ci-upstream/modules.yaml

--- a/v0.22/ci-upstream/packages.yaml
+++ b/v0.22/ci-upstream/packages.yaml
@@ -1,0 +1,1 @@
+../../common/ci/packages.yaml

--- a/v0.22/ci-upstream/repos.yaml
+++ b/v0.22/ci-upstream/repos.yaml
@@ -1,0 +1,1 @@
+../../common/repos.yaml


### PR DESCRIPTION
References ACCESS-NRI/build-ci#194

## Background

The current setup for CI 2.0 is that we will have a container that contains an upstream instance of `spack` with all the compilers (and possible low-level packages) that are needed, in order to speed up build times.
This container will connect to runner (downstream) instances of `spack`, which can use the compilers without needing to build or install them.

Hence we need to demarcate the two different use-cases for `ci` - one for upstream, and one for the runners (downstream). Here are the changes:

### Upstream

- `config.yaml` - the install_tree for upstream will be `/opt/upstream`
- `modules.yaml` - the modules directories will be `opt/upstream/modules`/`opt/upstream/lmod`

### Runners (downstream)

- `upstreams.yaml` - The upstream install_tree will be found in `/opt/upstream`, which (implementation details alert) is a mounted volume in the runner containers, pointing to the upstream `/opt/upstream` referenced above.


## Open Question

- @harshula, I was considering deleting `v0.22/ci/*.yaml` since it may not be used once this `docker compose` solution is set up. Is it okay if I delete them?
  - No
- Do we need to set this up for `ci/v0.20`/`ci/v0.21` as well...?
- Should this PR be going into `development` rather than `main`

## The PR

- **For ci/upstream, make install_tree/modules reference `/opt/upstream`**
- **For ci/runner, set upstream install_tree to be `/opt/upstream`**
- **Add symlinked v0.22/ci/upstream config**
- **Add symlinked v0.22/ci/runner config**
