### PR TITLE
Set `ci-runner` concretizer and view configuration in higher scope 

### DIFF
--- a/common/ci-runner/concretizer.yaml
+++ b/common/ci-runner/concretizer.yaml
@@ -1,4 +1,5 @@
 concretizer:
+  # Don't unify dependencies due to possibility of package clashes in CI
   unify: false
   targets:
     # Completely ignoring higher-level configuration options is supported with the :: notation for keys ...

--- a/common/ci-runner/concretizer.yaml
+++ b/common/ci-runner/concretizer.yaml
@@ -1,5 +1,5 @@
 concretizer:
-  unify: when_possible
+  unify: false
   targets:
     # Completely ignoring higher-level configuration options is supported with the :: notation for keys ...
     granularity:: generic

--- a/common/ci-runner/concretizer.yaml
+++ b/common/ci-runner/concretizer.yaml
@@ -1,0 +1,5 @@
+concretizer:
+  unify: when_possible
+  targets:
+    # Completely ignoring higher-level configuration options is supported with the :: notation for keys ...
+    granularity:: generic

--- a/common/ci-runner/injected.view.yaml
+++ b/common/ci-runner/injected.view.yaml
@@ -1,5 +1,5 @@
 # While not a true spack configuration file, this view snippet is injected
-#  into build-ci spack manifests to consistently disable views.
+#  into build-ci spack manifests to disable views by default.
 # This is used to get around the error of projections having the same prefix
-#  when using concretizer.unify:when_possible.
+#  when using concretizer.unify:when_possible/false.
 view: false

--- a/common/ci-runner/injected.view.yaml
+++ b/common/ci-runner/injected.view.yaml
@@ -1,10 +1,5 @@
 # While not a true spack configuration file, this view snippet is injected
-#  into build-ci spack manifests to consistently configure a custom view for the
-#  CI runner.
+#  into build-ci spack manifests to consistently disable views.
 # This is used to get around the error of projections having the same prefix
 #  when using concretizer.unify:when_possible.
-view:
-  default:
-    root: $SPACK_ROOT/../views
-    projections:
-      all: '{name}/{version}-{compiler.name}-{compiler.version}-{hash:7}'
+view: false

--- a/common/ci-runner/injected.view.yaml
+++ b/common/ci-runner/injected.view.yaml
@@ -1,0 +1,10 @@
+# While not a true spack configuration file, this view snippet is injected
+#  into build-ci spack manifests to consistently configure a custom view for the
+#  CI runner.
+# This is used to get around the error of projections having the same prefix
+#  when using concretizer.unify:when_possible.
+view:
+  default:
+    root: $SPACK_ROOT/../views
+    projections:
+      all: '{name}/{version}-{compiler.name}-{compiler.version}-{hash:7}'

--- a/v0.22/ci-runner/concretizer.yaml
+++ b/v0.22/ci-runner/concretizer.yaml
@@ -1,1 +1,1 @@
-../../common/concretizer.yaml
+../../common/ci-runner/concretizer.yaml

--- a/v0.22/ci-runner/injected.view.yaml
+++ b/v0.22/ci-runner/injected.view.yaml
@@ -1,0 +1,1 @@
+../../common/ci-runner/injected.view.yaml


### PR DESCRIPTION
References ACCESS-NRI/build-ci#195

## Background

It seems that build-ci spack manifests should almost always use `concretizer.unify: when_possible/false` as the concretization will fail when installing multiple of the same model component packages. Instead of having to create a schema on build-ci spack manifests, we should set this configuration higher up than the environment level (namely, here!).

This only solves half the problem, though. If a view can't be created due to having the same prefix (say, installing two `mom5`s with different compilers) the installation will fail. Hence we either need to have no view (which needs to be tested), or we need to set a custom `spack.views.default.projections` section in the spack manifest. Since it's not a first order configuration file (like `config.yaml` or `concretizer.yaml`, we need to inject this file into the environment. This is why it's called `injected.view.yaml`. 

## The PR
- **Update ci-runner concretizer to contain unify: false**
- **Create injected.view.yaml snippet for ci-runner spack manifests**
