### PR TITLE
Increase `.spack-db` lock timeout from 1 to 10 mins

### DIFF
--- a/common/config.yaml
+++ b/common/config.yaml
@@ -6,3 +6,6 @@ config:
   source_cache: $spack/../sourcecache
   # Available in v0.20.0
   environments_root: $spack/../environments
+  # Increasing from 1 minute to 10 minutes to allow for concurrent builds
+  # to wait longer for .spack-db lock rather than exiting early.
+  db_lock_timeout: 600


### PR DESCRIPTION
References ACCESS-NRI/build-cd#225
Pinging @aidanheerdegen as he helped out with this. 

## Background

Under heavy concurrent access, the spack database will lock and the installations using it will timeout after a minute. This means that if multiple of the same package needs to be installed, there is a chance that the builds will fail after a minute if the lock isn't released. 

We are increasing this timeout from 1 to 10 minutes to make this possibility less likely, pending a more robust solution in which we use a per-build containerised spack instead of one on the Gadi filesystem. 

## In this PR

* Increase DB lockout from 1 to 10 minutes, affecting `gadi`, `setonix`, `ci-runner` under all `v0.XX` directories, since they all symlink to this file. 
