### PR TITLE
Use v0.22 config files as preliminary config files for v0.23 and v1.0

### DIFF
--- a/v0.23/ci-runner/concretizer.yaml
+++ b/v0.23/ci-runner/concretizer.yaml
@@ -1,0 +1,1 @@
+../../common/concretizer.yaml

--- a/v0.23/ci-runner/config.yaml
+++ b/v0.23/ci-runner/config.yaml
@@ -1,0 +1,1 @@
+../../common/config.yaml

--- a/v0.23/ci-runner/modules.yaml
+++ b/v0.23/ci-runner/modules.yaml
@@ -1,0 +1,1 @@
+../../common/modules.yaml

--- a/v0.23/ci-runner/packages.yaml
+++ b/v0.23/ci-runner/packages.yaml
@@ -1,0 +1,1 @@
+../../common/ci/packages.yaml

--- a/v0.23/ci-runner/repos.yaml
+++ b/v0.23/ci-runner/repos.yaml
@@ -1,0 +1,1 @@
+../../common/repos.yaml

--- a/v0.23/ci-runner/upstreams.yaml
+++ b/v0.23/ci-runner/upstreams.yaml
@@ -1,0 +1,1 @@
+../../common/ci-runner/upstreams.yaml

--- a/v0.23/ci-upstream/concretizer.yaml
+++ b/v0.23/ci-upstream/concretizer.yaml
@@ -1,0 +1,1 @@
+../../common/concretizer.yaml

--- a/v0.23/ci-upstream/config.yaml
+++ b/v0.23/ci-upstream/config.yaml
@@ -1,0 +1,1 @@
+../../common/ci-upstream/config.yaml

--- a/v0.23/ci-upstream/modules.yaml
+++ b/v0.23/ci-upstream/modules.yaml
@@ -1,0 +1,1 @@
+../../common/ci-upstream/modules.yaml

--- a/v0.23/ci-upstream/packages.yaml
+++ b/v0.23/ci-upstream/packages.yaml
@@ -1,0 +1,1 @@
+../../common/ci/packages.yaml

--- a/v0.23/ci-upstream/repos.yaml
+++ b/v0.23/ci-upstream/repos.yaml
@@ -1,0 +1,1 @@
+../../common/repos.yaml

--- a/v0.23/ci/concretizer.yaml
+++ b/v0.23/ci/concretizer.yaml
@@ -1,0 +1,1 @@
+../../common/concretizer.yaml

--- a/v0.23/ci/config.yaml
+++ b/v0.23/ci/config.yaml
@@ -1,0 +1,1 @@
+../../common/config.yaml

--- a/v0.23/ci/modules.yaml
+++ b/v0.23/ci/modules.yaml
@@ -1,0 +1,1 @@
+../../common/modules.yaml

--- a/v0.23/ci/packages.yaml
+++ b/v0.23/ci/packages.yaml
@@ -1,0 +1,1 @@
+../../common/ci/packages.yaml

--- a/v0.23/ci/repos.yaml
+++ b/v0.23/ci/repos.yaml
@@ -1,0 +1,1 @@
+../../common/repos.yaml

--- a/v0.23/gadi/concretizer.yaml
+++ b/v0.23/gadi/concretizer.yaml
@@ -1,0 +1,1 @@
+../../common/concretizer.yaml

--- a/v0.23/gadi/config.yaml
+++ b/v0.23/gadi/config.yaml
@@ -1,0 +1,1 @@
+../../common/config.yaml

--- a/v0.23/gadi/linux/compilers.yaml
+++ b/v0.23/gadi/linux/compilers.yaml
@@ -1,0 +1,1 @@
+../../../common/gadi/linux/compilers.yaml

--- a/v0.23/gadi/modules.yaml
+++ b/v0.23/gadi/modules.yaml
@@ -1,0 +1,1 @@
+../../common/modules.yaml

--- a/v0.23/gadi/packages.yaml
+++ b/v0.23/gadi/packages.yaml
@@ -1,0 +1,1 @@
+../../common/gadi/packages.yaml

--- a/v0.23/gadi/repos.yaml
+++ b/v0.23/gadi/repos.yaml
@@ -1,0 +1,1 @@
+../../common/repos.yaml

--- a/v0.23/setonix/concretizer.yaml
+++ b/v0.23/setonix/concretizer.yaml
@@ -1,0 +1,1 @@
+../../common/concretizer.yaml

--- a/v0.23/setonix/config.yaml
+++ b/v0.23/setonix/config.yaml
@@ -1,0 +1,1 @@
+../../common/config.yaml

--- a/v0.23/setonix/modules.yaml
+++ b/v0.23/setonix/modules.yaml
@@ -1,0 +1,1 @@
+../../common/modules.yaml

--- a/v0.23/setonix/packages.yaml
+++ b/v0.23/setonix/packages.yaml
@@ -1,0 +1,1 @@
+../../common/setonix/packages.yaml

--- a/v0.23/setonix/repos.yaml
+++ b/v0.23/setonix/repos.yaml
@@ -1,0 +1,1 @@
+../../common/repos.yaml

--- a/v1.0/ci-runner/concretizer.yaml
+++ b/v1.0/ci-runner/concretizer.yaml
@@ -1,0 +1,1 @@
+../../common/concretizer.yaml

--- a/v1.0/ci-runner/config.yaml
+++ b/v1.0/ci-runner/config.yaml
@@ -1,0 +1,1 @@
+../../common/config.yaml

--- a/v1.0/ci-runner/modules.yaml
+++ b/v1.0/ci-runner/modules.yaml
@@ -1,0 +1,1 @@
+../../common/modules.yaml

--- a/v1.0/ci-runner/packages.yaml
+++ b/v1.0/ci-runner/packages.yaml
@@ -1,0 +1,1 @@
+../../common/ci/packages.yaml

--- a/v1.0/ci-runner/repos.yaml
+++ b/v1.0/ci-runner/repos.yaml
@@ -1,0 +1,1 @@
+../../common/repos.yaml

--- a/v1.0/ci-runner/upstreams.yaml
+++ b/v1.0/ci-runner/upstreams.yaml
@@ -1,0 +1,1 @@
+../../common/ci-runner/upstreams.yaml

--- a/v1.0/ci-upstream/concretizer.yaml
+++ b/v1.0/ci-upstream/concretizer.yaml
@@ -1,0 +1,1 @@
+../../common/concretizer.yaml

--- a/v1.0/ci-upstream/config.yaml
+++ b/v1.0/ci-upstream/config.yaml
@@ -1,0 +1,1 @@
+../../common/ci-upstream/config.yaml

--- a/v1.0/ci-upstream/modules.yaml
+++ b/v1.0/ci-upstream/modules.yaml
@@ -1,0 +1,1 @@
+../../common/ci-upstream/modules.yaml

--- a/v1.0/ci-upstream/packages.yaml
+++ b/v1.0/ci-upstream/packages.yaml
@@ -1,0 +1,1 @@
+../../common/ci/packages.yaml

--- a/v1.0/ci-upstream/repos.yaml
+++ b/v1.0/ci-upstream/repos.yaml
@@ -1,0 +1,1 @@
+../../common/repos.yaml

--- a/v1.0/ci/concretizer.yaml
+++ b/v1.0/ci/concretizer.yaml
@@ -1,0 +1,1 @@
+../../common/concretizer.yaml

--- a/v1.0/ci/config.yaml
+++ b/v1.0/ci/config.yaml
@@ -1,0 +1,1 @@
+../../common/config.yaml

--- a/v1.0/ci/modules.yaml
+++ b/v1.0/ci/modules.yaml
@@ -1,0 +1,1 @@
+../../common/modules.yaml

--- a/v1.0/ci/packages.yaml
+++ b/v1.0/ci/packages.yaml
@@ -1,0 +1,1 @@
+../../common/ci/packages.yaml

--- a/v1.0/ci/repos.yaml
+++ b/v1.0/ci/repos.yaml
@@ -1,0 +1,1 @@
+../../common/repos.yaml

--- a/v1.0/gadi/concretizer.yaml
+++ b/v1.0/gadi/concretizer.yaml
@@ -1,0 +1,1 @@
+../../common/concretizer.yaml

--- a/v1.0/gadi/config.yaml
+++ b/v1.0/gadi/config.yaml
@@ -1,0 +1,1 @@
+../../common/config.yaml

--- a/v1.0/gadi/linux/compilers.yaml
+++ b/v1.0/gadi/linux/compilers.yaml
@@ -1,0 +1,1 @@
+../../../common/gadi/linux/compilers.yaml

--- a/v1.0/gadi/modules.yaml
+++ b/v1.0/gadi/modules.yaml
@@ -1,0 +1,1 @@
+../../common/modules.yaml

--- a/v1.0/gadi/packages.yaml
+++ b/v1.0/gadi/packages.yaml
@@ -1,0 +1,1 @@
+../../common/gadi/packages.yaml

--- a/v1.0/gadi/repos.yaml
+++ b/v1.0/gadi/repos.yaml
@@ -1,0 +1,1 @@
+../../common/repos.yaml

--- a/v1.0/setonix/concretizer.yaml
+++ b/v1.0/setonix/concretizer.yaml
@@ -1,0 +1,1 @@
+../../common/concretizer.yaml

--- a/v1.0/setonix/config.yaml
+++ b/v1.0/setonix/config.yaml
@@ -1,0 +1,1 @@
+../../common/config.yaml

--- a/v1.0/setonix/modules.yaml
+++ b/v1.0/setonix/modules.yaml
@@ -1,0 +1,1 @@
+../../common/modules.yaml

--- a/v1.0/setonix/packages.yaml
+++ b/v1.0/setonix/packages.yaml
@@ -1,0 +1,1 @@
+../../common/setonix/packages.yaml

--- a/v1.0/setonix/repos.yaml
+++ b/v1.0/setonix/repos.yaml
@@ -1,0 +1,1 @@
+../../common/repos.yaml


### PR DESCRIPTION
### Testing

* `v1.0` config is untested
* `v0.23` config tested with Docker:
```
[root@e9a3fc5396b0 opt]# spack -V
0.23.1 (2bfcc69fa870d3c6919be87593f22647981b648a)

[om2] [root@e9a3fc5396b0 opt]# spack find -c
==> In environment om2
==> 1 root specs
 -  access-om2@git.2024.03.0=2024.03.0

-- linux-rocky8-x86_64 / intel@2021.10.0 ------------------------
 -   access-om2@git.2024.03.0=2024.03.0
[+]  autoconf@2.72
[+]  automake@1.16.5
[+]  bison@3.8.2
[+]  bzip2@1.0.8
[+]  ca-certificates-mozilla@2023-05-30
 -   cice5@git.2023.10.19=access-om2
[+]  cmake@3.24.4
[+]  curl@8.10.1
 -   datetime-fortran@1.7.0
[+]  diffutils@3.10
[+]  findutils@4.9.0
[+]  gettext@0.22.5
[e]  glibc@2.28
[+]  gmake@4.4.1
 -   hdf5@1.14.5
[+]  hwloc@2.11.1
 -   json-fortran@8.3.0
 -   krb5@1.21.3
 -   libaccessom2@git.2023.10.26=access-om2
[+]  libedit@3.1-20240808
[+]  libevent@2.1.12
[+]  libpciaccess@0.17
[+]  libsigsegv@2.14
[+]  libtool@2.4.6
[+]  libxcrypt@4.4.35
[+]  libxml2@2.13.4
[+]  m4@1.4.19
 -   mom5@git.2023.11.09=access-om2
[+]  ncurses@6.5
 -   netcdf-c@4.7.4
 -   netcdf-fortran@4.5.2
[+]  nghttp2@1.63.0
 -   numactl@2.0.18
 -   oasis3-mct@git.2023.11.09=access-om2
 -   openmpi@4.0.2
 -   openssh@9.9p1
[+]  openssl@3.4.0
 -   parallelio@2.5.2
[e]  perl@5.26.3
[+]  pigz@2.8
[+]  pkgconf@2.2.0
[+]  pmix@4.2.2
[+]  tar@1.34
[+]  util-macros@1.20.1
[+]  xz@5.4.6
[+]  zlib-ng@2.2.1
[+]  zstd@1.5.6
==> 33 installed packages
==> 15 concretized packages to be installed

==> Waiting for access-om2-git.2024.03.0=2024.03.0-izxpeghneqyv3intcbnqltqznwgn2==> Installing access-om2-git.2024.03.0=2024.03.0-izxpeghneqyv3intcbnqltqznwgn2gxj [46/46]
==> No binary for access-om2-git.2024.03.0=2024.03.0-izxpeghneqyv3intcbnqltqznwgn2gxj found: installing from source
==> No patches needed for access-om2
==> access-om2: Executing phase: 'install'
==> access-om2: Successfully installed access-om2-git.2024.03.0=2024.03.0-izxpeghneqyv3intcbnqltqznwgn2gxj
  Stage: 0.00s.  Install: 0.00s.  Post-install: 0.13s.  Total: 0.22s
[+] /opt/release/linux-rocky8-x86_64/intel-2021.10.0/access-om2-git.2024.03.0_2024.03.0-izxpeghneqyv3intcbnqltqznwgn2gxj
```