### PR TITLE
common/gadi/linux/compilers.yaml: add new oneapi 2025.1.1 compiler

### DIFF
--- a/common/gadi/linux/compilers.yaml
+++ b/common/gadi/linux/compilers.yaml
@@ -404,6 +404,19 @@ compilers::
     environment: {}
     extra_rpaths: []
 - compiler:
+    spec: oneapi@=2025.1.1
+    paths:
+      cc: /apps/intel-tools/wrappers/icx
+      cxx: /apps/intel-tools/wrappers/icpx
+      f77: /apps/intel-tools/wrappers/ifx
+      fc: /apps/intel-tools/wrappers/ifx
+    flags: {}
+    operating_system: rocky8
+    target: x86_64
+    modules: [intel-compiler-llvm/2025.1.1]
+    environment: {}
+    extra_rpaths: []
+- compiler:
     spec: gcc@=10.3.0
     paths:
       cc: /apps/gcc/10.3.0/wrappers/gcc


### PR DESCRIPTION
### Testing
```
$ spack compiler list
==> Available compilers
-- clang rocky8-x86_64 ------------------------------------------
clang@17.0.6

-- gcc rocky8-x86_64 --------------------------------------------
gcc@8.5.0  gcc@14.1.0  gcc@13.2.0  gcc@12.2.0  gcc@11.1.0  gcc@10.3.0

-- intel rocky8-x86_64 ------------------------------------------
intel@2021.8.0  intel@2021.3.0   intel@19.1.3.304  intel@19.0.4.243
intel@2021.7.0  intel@2021.2.0   intel@19.1.2.254  intel@19.0.3.199
intel@2021.6.0  intel@2021.11.1  intel@19.1.1.217
intel@2021.5.0  intel@2021.10.0  intel@19.1.0.166
intel@2021.4.0  intel@2021.1     intel@19.0.5.281

-- oneapi rocky8-x86_64 -----------------------------------------
oneapi@2025.1.1  oneapi@2023.2.0  oneapi@2022.0.0  oneapi@2021.1
oneapi@2025.0.4  oneapi@2023.0.0  oneapi@2021.4.0
oneapi@2024.2.1  oneapi@2022.2.0  oneapi@2021.3.0
oneapi@2024.0.2  oneapi@2022.1.0  oneapi@2021.2.0
```