### PR TITLE
common/gadi/linux/compilers.yaml: add new oneapi 2025.2.0 compiler

### DIFF
--- a/common/gadi/linux/compilers.yaml
+++ b/common/gadi/linux/compilers.yaml
@@ -417,6 +417,19 @@ compilers::
     environment: {}
     extra_rpaths: []
 - compiler:
+    spec: oneapi@=2025.2.0
+    paths:
+      cc: /apps/intel-tools/wrappers/icx
+      cxx: /apps/intel-tools/wrappers/icpx
+      f77: /apps/intel-tools/wrappers/ifx
+      fc: /apps/intel-tools/wrappers/ifx
+    flags: {}
+    operating_system: rocky8
+    target: x86_64
+    modules: [intel-compiler-llvm/2025.2.0]
+    environment: {}
+    extra_rpaths: []
+- compiler:
     spec: gcc@=10.3.0
     paths:
       cc: /apps/gcc/10.3.0/wrappers/gcc


### PR DESCRIPTION
OneAPI 2025.2.0 is installed and available on Gadi. Add support for it in Spack.