### PR TITLE
Update repos.yaml to support Spack v1.0

### DIFF
--- a/v1.0/all/repos.yaml
+++ b/v1.0/all/repos.yaml
@@ -1,0 +1,3 @@
+# Completely ignoring higher-level configuration options is supported with the :: notation for keys ...
+repos:
+- $spack/../spack-packages/spack_repo/access/nri

--- a/v1.0/ci-runner/repos.yaml
+++ b/v1.0/ci-runner/repos.yaml
@@ -1,1 +1,1 @@
-../../common/repos.yaml
+../all/repos.yaml

--- a/v1.0/ci-upstream/repos.yaml
+++ b/v1.0/ci-upstream/repos.yaml
@@ -1,1 +1,1 @@
-../../common/repos.yaml
+../all/repos.yaml

--- a/v1.0/ci/repos.yaml
+++ b/v1.0/ci/repos.yaml
@@ -1,1 +1,1 @@
-../../common/repos.yaml
+../all/repos.yaml

--- a/v1.0/gadi/repos.yaml
+++ b/v1.0/gadi/repos.yaml
@@ -1,1 +1,1 @@
-../../common/repos.yaml
+../all/repos.yaml

--- a/v1.0/setonix/repos.yaml
+++ b/v1.0/setonix/repos.yaml
@@ -1,1 +1,1 @@
-../../common/repos.yaml
+../all/repos.yaml


### PR DESCRIPTION
### Testing
```
[root@5596be3dc7c1 fncqgg4]# spack config blame repos
---                                          repos:
/opt/spack/etc/spack/repos.yaml:3              access.nri: $spack/../spack-packages/spack_repo/access/nri
/opt/spack/etc/spack/defaults/repos.yaml:14    builtin:
/opt/spack/etc/spack/defaults/repos.yaml:15      git: https://github.com/spack/spack-packages.git
/opt/spack/etc/spack/defaults/repos.yaml:16      branch: releases/v2025.07

[root@5596be3dc7c1 spack]# spack -V
1.0.0 (73eaea13f381e3495299284856fd02a64e1d154c)

[root@5596be3dc7c1 spack]# ls -l
total 4
lrwxrwxrwx 1 root root   45 Aug  7 07:06 concretizer.yaml -> ../../../spack-config/common/concretizer.yaml
lrwxrwxrwx 1 root root   40 Aug  7 07:06 config.yaml -> ../../../spack-config/common/config.yaml
drwxr-xr-x 6 root root 4096 Aug  7 07:06 defaults
lrwxrwxrwx 1 root root   41 Aug  7 07:06 modules.yaml -> ../../../spack-config/common/modules.yaml
lrwxrwxrwx 1 root root   45 Aug  7 07:06 packages.yaml -> ../../../spack-config/common/ci/packages.yaml
lrwxrwxrwx 1 root root   41 Aug  7 07:06 repos.yaml -> ../../../spack-config/v1.0/all/repos.yaml
```