### PR TITLE
Spack v1.0: repos.yaml: override Spack's builtin repo settings

### DIFF
--- a/v1.0/all/repos.yaml
+++ b/v1.0/all/repos.yaml
@@ -1,3 +1,7 @@
 # Completely ignoring higher-level configuration options is supported with the :: notation for keys ...
-repos:
-- $spack/../spack-packages/spack_repo/access/nri
+repos::
+  access_spack_packages: $spack/../spack-packages/spack_repo/access/nri
+  builtin:
+    git: https://github.com/spack/spack-packages.git
+    # Fix external Intel classic compiler (#981)
+    commit: 1788fb4b16f4e1478e149de56ba3040d8d5f51d6


### PR DESCRIPTION
We were reliant on a bug in Spack v1.0 for our Docker image build containing Spack v1.0 and ifort 2021.10.0. This bug was fixed in Spack v1.0.1: https://github.com/spack/spack/pull/51105 .

We need https://github.com/spack/spack-packages/pull/981 for our Docker image build containing Spack v1.0 and ifort 2021.10.0. This can be forced by this PR. 

NOTE: There's a broader discussion we need to have about how we manage all the Spack related repositories.