### PR TITLE
Concurrent Package Installation for `ci-upstream` using `spack v1.0`

### DIFF
--- a/v1.0/ci-upstream/config.yaml
+++ b/v1.0/ci-upstream/config.yaml
@@ -1,1 +1,0 @@
-../../common/ci-upstream/config.yaml

--- a/v1.0/ci-upstream/config.yaml
+++ b/v1.0/ci-upstream/config.yaml
@@ -1,0 +1,13 @@
+config:
+  install_tree:
+    # Completely ignoring higher-level configuration options is supported with the :: notation for keys ...
+    root:: $spack/../release
+  # Available in v0.20.0
+  source_cache: $spack/../sourcecache
+  # Available in v0.20.0
+  environments_root: $spack/../environments
+  # Increasing from 1 minute to 10 minutes to allow for concurrent builds
+  # to wait longer for .spack-db lock rather than exiting early.
+  db_lock_timeout: 600
+  # Building the upstream image takes a long time, so we increase the package install concurrency
+  concurrent_packages: 5


### PR DESCRIPTION
## Background

Building the upstream image takes an exceptionally long time. Luckily `spack v1.0` allows concurrent installation of packages, which offers a significant speedup.

This PR is used to test out both the self-hosted and GitHub-hosted variants of the CI. 

For the GitHub-hosted variant, this update should be uncontroversial, but the self-hosted variant must be mindful of the kuberenetes node resources - test this. 

## The PR

- **Delete v1.0/ci-upstream/config symlink**
- **Add v1.0/ci-upstream/config.yaml with concurrent packages directive**

## Testing

Add when done!
