### PR TITLE
Make `perl` buildable for `ci`

### DIFF
--- a/v1.0/ci-runner/packages.yaml
+++ b/v1.0/ci-runner/packages.yaml
@@ -1,1 +1,1 @@
-v1.0/ci/packages.yaml
+../ci/packages.yaml

--- a/v1.0/ci-runner/packages.yaml
+++ b/v1.0/ci-runner/packages.yaml
@@ -1,1 +1,1 @@
-../../common/ci/packages.yaml
+v1.0/ci/packages.yaml

--- a/v1.0/ci-upstream/packages.yaml
+++ b/v1.0/ci-upstream/packages.yaml
@@ -1,1 +1,1 @@
-v1.0/ci/packages.yaml
+../ci/packages.yaml

--- a/v1.0/ci-upstream/packages.yaml
+++ b/v1.0/ci-upstream/packages.yaml
@@ -1,1 +1,1 @@
-../../common/ci/packages.yaml
+v1.0/ci/packages.yaml

--- a/v1.0/ci/packages.yaml
+++ b/v1.0/ci/packages.yaml
@@ -1,1 +1,11 @@
-../../common/ci/packages.yaml
+packages:
+  cmake:
+    # Syntax for requirement:
+    require:
+    - one_of:
+      - "@3.31.6"  # v1.0 spack
+      - "@3.24.4"  # v0.22 spack
+    # Syntax for preference:
+    #version: [3.31.6, 3.24.4]
+  libtool:
+    version: [:2.4.6]


### PR DESCRIPTION
Closes #74

## Background

`spack v1.0` can't seem to determine what compiler the extermal `perl` package was built with, which play havoc with concretization. 

For `v1.0/ci`, we have made it a buildable, non-external package. 

## The PR

- **Break v1.0/ci/packages.yaml symlink, readd with removed perl external**

## Testing

Done in https://github.com/ACCESS-NRI/MOM6/actions/runs/17788157865/job/50560745591?pr=24
