### PR TITLE
packages.yaml: use `require` instead of `providers` for mpi

### DIFF
--- a/common-api-v2/gadi/packages.yaml
+++ b/common-api-v2/gadi/packages.yaml
@@ -1,8 +1,7 @@
 packages:
-  all:
-    providers:
-      # Completely ignoring higher-level configuration options is supported with the :: notation for keys ...
-      mpi:: [openmpi]
+  # Completely ignoring lower-precedence configuration options is supported with the :: notation for keys
+  mpi::
+    require: openmpi
   cmake:
     externals:
     - spec: cmake@3.24.2

--- a/common/ci/packages.yaml
+++ b/common/ci/packages.yaml
@@ -1,4 +1,7 @@
 packages:
+  # Completely ignoring lower-precedence configuration options is supported with the :: notation for keys
+  mpi::
+    require: openmpi
   perl:
     externals:
     - spec: perl@5.26.3

--- a/common/gadi/packages.yaml
+++ b/common/gadi/packages.yaml
@@ -1,8 +1,7 @@
 packages:
-  all:
-    providers:
-      # Completely ignoring higher-level configuration options is supported with the :: notation for keys ...
-      mpi:: [openmpi]
+  # Completely ignoring lower-precedence configuration options is supported with the :: notation for keys
+  mpi::
+    require: openmpi
   cmake:
     externals:
     - spec: cmake@3.24.2

--- a/common/setonix/packages.yaml
+++ b/common/setonix/packages.yaml
@@ -1,4 +1,7 @@
 packages:
+  # Completely ignoring lower-precedence configuration options is supported with the :: notation for keys
+  mpi::
+    require: mpich
   perl:
     externals:
     - spec: perl@5.26.1


### PR DESCRIPTION
* Spack upstream informed us that `providers` indicates a preference, not a requirement.
* Default to `openmpi` on Gadi and CI. Default to `mpich` on Setonix.
* This can be overridden from the spack.yaml environment file.
* https://spack.readthedocs.io/en/latest/configuration.html#scope-precedence