### PR TITLE
Separate `config.yaml` for `ci-upstream` based on spack version

### DIFF
--- a/common/ci-runner/upstreams.yaml
+++ b/common/ci-runner/upstreams.yaml
@@ -1,5 +1,0 @@
-upstreams:
-  upstream:
-    # Assumes that from the runners point of view, the volume mount 
-    # point for the containerised upstream install_tree is /opt/upstream
-    install_tree: /opt/upstream

--- a/v0.22/ci-runner/upstreams.yaml
+++ b/v0.22/ci-runner/upstreams.yaml
@@ -1,1 +1,5 @@
-../../common/ci-runner/upstreams.yaml
+upstreams:
+  upstream:
+    # Assumes that from the runners point of view, the volume mount
+    # point for the containerised upstream install_tree is /opt/upstream
+    install_tree: /opt/upstream

--- a/v0.23/ci-runner/upstreams.yaml
+++ b/v0.23/ci-runner/upstreams.yaml
@@ -1,1 +1,5 @@
-../../common/ci-runner/upstreams.yaml
+upstreams:
+  upstream:
+    # Assumes that from the runners point of view, the volume mount
+    # point for the containerised upstream install_tree is /opt/upstream
+    install_tree: /opt/upstream

--- a/v1.0/ci-runner/upstreams.yaml
+++ b/v1.0/ci-runner/upstreams.yaml
@@ -1,1 +1,5 @@
-../../common/ci-runner/upstreams.yaml
+upstreams:
+  upstream:
+    # Assumes that from the runners point of view, the volume mount
+    # point for the containerised upstream install_tree is /opt/upstream-v1.0 (for spack v1.0)
+    install_tree: /opt/upstream-v1.0

--- a/v1.0/ci-upstream/config.yaml
+++ b/v1.0/ci-upstream/config.yaml
@@ -1,1 +1,8 @@
-../../common/ci-upstream/config.yaml
+config:
+  install_tree:
+    # Completely ignoring higher-level configuration options is supported with the :: notation for keys ...
+    root:: $spack/../upstream-v1.0
+  # Available in v0.20.0
+  source_cache: $spack/../sourcecache
+  # Available in v0.20.0
+  environments_root: $spack/../environments


### PR DESCRIPTION
References ACCESS-NRI/build-ci#247

## Background

Currently, for `0.22` and `1.0` spack runners, we use a `0.22` upstream image for compatibility between the two. 

Unfortunately, the `1.0` runner doesn't understand what compilers are used in a `0.22` upstream, noting them as `no compiler`. This means that there is no upstream caching for `1.0` images. 

In order to fix this, we need to have two different `0.22` and `1.0` upstreams in the cluster. This means different `config.install_tree`s for different versions of `spack`, as install trees are not relocatable. 

## The PR

- unlink `v*/ci-runner/upstreams.yaml`, activate upstreams based on spack versions
- Make v1.0 ci-upstream install_tree the same path as the volume mount

## Testing

See ACCESS-NRI/build-ci#248
