### PR TITLE
Update old comment from Spack docs

### DIFF
--- a/common-api-v2/repos.yaml
+++ b/common-api-v2/repos.yaml
@@ -1,4 +1,4 @@
-# Completely ignoring higher-level configuration options is supported with the :: notation for keys ...
+# Completely ignoring lower-precedence configuration options is supported with the :: notation for keys
 repos::
   access_spack_packages: $spack/../spack-packages/spack_repo/access/nri
   builtin:

--- a/common/ci-runner/concretizer.yaml
+++ b/common/ci-runner/concretizer.yaml
@@ -2,5 +2,5 @@ concretizer:
   # Don't unify dependencies due to possibility of package clashes in CI
   unify: false
   targets:
-    # Completely ignoring higher-level configuration options is supported with the :: notation for keys ...
+    # Completely ignoring lower-precedence configuration options is supported with the :: notation for keys
     granularity:: generic

--- a/common/ci-upstream/config.yaml
+++ b/common/ci-upstream/config.yaml
@@ -1,6 +1,6 @@
 config:
   install_tree:
-    # Completely ignoring higher-level configuration options is supported with the :: notation for keys ...
+    # Completely ignoring lower-precedence configuration options is supported with the :: notation for keys
     root:: $spack/../upstream
   # Available in v0.20.0
   source_cache: $spack/../sourcecache

--- a/common/concretizer.yaml
+++ b/common/concretizer.yaml
@@ -1,4 +1,4 @@
 concretizer:
   targets:
-    # Completely ignoring higher-level configuration options is supported with the :: notation for keys ...
+    # Completely ignoring lower-precedence configuration options is supported with the :: notation for keys
     granularity:: generic

--- a/common/config.yaml
+++ b/common/config.yaml
@@ -1,6 +1,6 @@
 config:
   install_tree:
-    # Completely ignoring higher-level configuration options is supported with the :: notation for keys ...
+    # Completely ignoring lower-precedence configuration options is supported with the :: notation for keys
     root:: $spack/../release
   # Available in v0.20.0
   source_cache: $spack/../sourcecache

--- a/common/gadi/linux/compilers.yaml
+++ b/common/gadi/linux/compilers.yaml
@@ -1,4 +1,4 @@
-# Completely ignoring higher-level configuration options is supported with the :: notation for keys ...
+# Completely ignoring lower-precedence configuration options is supported with the :: notation for keys
 compilers::
 - compiler:
     spec: clang@=17.0.6

--- a/common/repos.yaml
+++ b/common/repos.yaml
@@ -1,4 +1,4 @@
-# Completely ignoring higher-level configuration options is supported with the :: notation for keys ...
+# Completely ignoring lower-precedence configuration options is supported with the :: notation for keys
 repos::
 - $spack/../spack-packages
 - $spack/var/spack/repos/builtin


### PR DESCRIPTION
https://spack.readthedocs.io/en/v0.22.0/configuration.html: "Completely ignoring higher-level configuration options is supported with the :: notation for keys"

https://spack.readthedocs.io/en/v0.23.0/configuration.html: "Completely ignoring lower-precedence configuration options is supported with the :: notation for keys"
